### PR TITLE
Minor: fix sign in Claim 15.2.7

### DIFF
--- a/snargs-book.tex
+++ b/snargs-book.tex
@@ -9182,7 +9182,7 @@ This lets us derive the following bound:
  \frac{1}{2^{\SecurityParameter}}
 \\ & =
 \sum_{i = 2}^{\IPRoundComplexity}
-\frac{\ROQueryBound_{\RoundIndex} \cdot \ROQueryBound_{\RoundIndex+1}}{2^{\SecurityParameter}}
+\frac{\ROQueryBound_{\RoundIndex} \cdot \ROQueryBound_{\RoundIndex-1}}{2^{\SecurityParameter}}
 \enspace.
 \end{align*}
 \end{itemize}


### PR DESCRIPTION
The size of `I_{\RoundIndex-1}` is `\ROQueryBound_{\RoundIndex-1}`

The size of  `I_{\RoundIndex}` is `\ROQueryBound_{\RoundIndex}`