### PR TITLE
Fix a typo in the proof of Claim 1.2.10

### DIFF
--- a/snargs-book.tex
+++ b/snargs-book.tex
@@ -1734,7 +1734,7 @@ Then, by the equivalent definition of statistical distance (\Cref{definition:sta
 -
 \Pr\left[\RandomVariableY \in \RandomVariableSupport' \ConditionedOn \Event_{2}\right]
 }
-+ \Pr[\Negate{\Event_{2}}]
++ \Pr[\Negate{\Event_{1}}]
 \\ & =
 \StatisticalDistance{(\RandomVariableX \ConditionedOn \Event_{1})}{(\RandomVariableY \ConditionedOn \Event_{2})} + \Pr[\Negate{\Event_{1}}]
 \enspace.


### PR DESCRIPTION
The second last line of the proof should be adding the probability
of the negation of E_1, since this is obtained from the line right
above "Then, by the equivalent definition of statistical distance
(Equation 1.4)".
