### PR TITLE
Add \FSErrorExpression in proof of 16.1.1.

### DIFF
--- a/snargs-book.tex
+++ b/snargs-book.tex
@@ -9679,12 +9679,14 @@ Fix a $\ROQueryBound$-query malicious argument prover $\FastFSMaliciousProver$. 
 \EquationComment{by \Cref{lemma:slow-vs-fast:stat-distance}}
 \\ & \leq
 \ARGSlowKnowledgeError(\SecurityParameter,\ROQueryBound,\InstanceSize,\ProverFailureProbability{\SlowFSMaliciousProver})
++ \FSErrorExpression
 \EquationComment{by the knowledge soundness error for the $\ROQueryBound$-query prover $\SlowFSMaliciousProver^{\ROFunction}$}
 \\ & \leq
 \ARGSlowKnowledgeError\left(\SecurityParameter,\ROQueryBound,\InstanceSize,\ProverFailureProbability{\FastFSMaliciousProver} + \FSErrorExpression\right)
++ \FSErrorExpression
 \EquationComment{by \Cref{lemma:slow-vs-fast:stat-distance}, $\ProverFailureProbability{\SlowFSMaliciousProver} \leq \ProverFailureProbability{\FastFSMaliciousProver} + \FSErrorExpression$}
 \\ & \leq
-\IPSRKnowledgeError\left(\PrivacyParameter,\ROQueryBound,\InstanceSize,\ProverFailureProbability{\FastFSMaliciousProver} + \FSErrorExpression\right)
+\IPSRKnowledgeError\left(\PrivacyParameter,\ROQueryBound,\InstanceSize,\ProverFailureProbability{\FastFSMaliciousProver} + \FSErrorExpression\right) + \FSErrorExpression
 \EquationComment{by \Cref{theorem:slow-fs-knowledge-soundness}}
 \enspace.
 \end{align*}


### PR DESCRIPTION
In Theorem 16.1.1, the error of the fast FS appears twice, as error of the prover translation and as indistinguishability error. This commit accounts for the latter in the inequalities of the proof.