### PR TITLE
fix: typo in Lemma 1.4.4

### DIFF
--- a/snargs-book.tex
+++ b/snargs-book.tex
@@ -1857,7 +1857,7 @@ Our first step is to show that the expression is maximized when all but three of
 \end{align*}
 Then, we show that the expression with $\delta'_{1},\ldots,\delta'_n$ is greater (or equal) to the expression with $\delta_{1},\ldots,\delta_n$. Namely, we show that
 \begin{align*}
-\sum_{i=1}^{n} \delta_{i-1} \cdot \delta_{i} \leq \sum_{i=1}^{n} \delta'_{i-1} \cdot \delta'_{i}
+\sum_{i=2}^{n} \delta_{i-1} \cdot \delta_{i} \leq \sum_{i=2}^{n} \delta'_{i-1} \cdot \delta'_{i}
 \enspace.
 \end{align*}
 Most of the terms are the same on both sides. The terms that are different are those that include $i$ or $j$. Thus, the expression can be rewritten as


### PR DESCRIPTION
In the proof of lemma 1.4.4, at the middle sum starts from 1, but since delta_0 is not defined it should actually start from 2. I did not update the pdf file since I was not sure my compilation differs from yours or not. 