### PR TITLE
Allow lulatex versions 2024-2029 (esp. 2025).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: check-tex-version snargs-book.pdf
 
 check-tex-version:
 	@echo "Checking TeX distribution version..."
-	@lualatex --version | grep '2024' > /dev/null || (echo "ERROR: TeX distribution is not from 2024. Please update your TeX distribution." && false)
+	@lualatex --version | grep -E '202[4-9]' > /dev/null || (echo "ERROR: TeX distribution is not from 2024 or later. Please update your TeX distribution." && false)
 
 snargs-book.pdf: clean snargs-book.tex
 	latexmk -pdf -pdflatex="lualatex -interaction=nonstopmode -file-line-error -recorder" -use-make snargs-book.tex


### PR DESCRIPTION
Currently the makefile only accepts texlive tries to grep for version year "2024", which is out of date by now