### PR TITLE
Fix typo in 13.2.4

### DIFF
--- a/snargs-book.tex
+++ b/snargs-book.tex
@@ -8276,8 +8276,8 @@ Let $\IPSymbol=\IPSystem$ be an IP. A deterministic IP state-restoration prover 
 \begin{equation*}
 \Pr\left[
 \begin{array}{l}
-\SomeSize{\Instance} \leq \InstanceSize \\
-\land\;\IPVerifier\big(\IPVerifierInput\big)=0
+\SomeSize{\Instance} > \InstanceSize \\
+\lor\;\IPVerifier\big(\IPVerifierInput\big)=0
 \end{array}
 \GivenExperiment
 \StateExperiment{


### PR DESCRIPTION
If I am not mistaken there is a small typo in the definition of failure probability. Since we are looking at the probability of prover failing it should be "|x| > n or V(...) = 0", but currently it is "|x| <= n and V(...) = 0".